### PR TITLE
fix: useEvents effect called each time event source changes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -253,6 +253,6 @@ export const useEvents = <E extends TEvent>(events: Events<E>, send: Send<E>) =>
       events.subscribe((event) => {
         send(event);
       }),
-    [],
+    [events],
   );
 };


### PR DESCRIPTION
Came across this interesting scenario, wonder if the change makes sense.

The `events` source is recreated somewhere top level inside the application, but because the `useEffect` is only applied when the Provider mounts, the feature does not receive events emitted by the new source.